### PR TITLE
Extend README on model details

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ and released under
 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
 The model was created
 by fine-tuning the pre-trained
-[wav2vec2-large-robust model](https://huggingface.co/facebook/wav2vec2-large-robust)
-on
+[wav2vec2-large-robust](https://huggingface.co/facebook/wav2vec2-large-robust)
+model on
 [MSP-Podcast](https://ecs.utdallas.edu/research/researchlabs/msp-lab/MSP-Podcast.html)
 (v1.7).
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The hidden states might be used as embeddings
 for related speech emotion recognition tasks.
 The order in the logits output is:
 arousal,
-domiancen,
+dominance,
 valence.
 
 ## Tutorial

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ The model is available from
 [doi:10.5281/zenodo.6221127](https://doi.org/10.5281/zenodo.6221127)
 and released under
 [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).
+The model was created
+by fine-tuning the pre-trained
+[wav2vec2-large-robust model](https://huggingface.co/facebook/wav2vec2-large-robust)
+on
+[MSP-Podcast](https://ecs.utdallas.edu/research/researchlabs/msp-lab/MSP-Podcast.html)
+(v1.7).
 
 ## Quick start
 
@@ -42,6 +48,13 @@ model(signal, sampling_rate)
           0.00952989,  0.00269193]], dtype=float32),
  'logits': array([[0.6717072 , 0.6421313 , 0.49881312]], dtype=float32)}
 ```
+
+The hidden states might be used as embeddings
+for related speech emotion recognition tasks.
+The order in the logits output is:
+arousal,
+domiancen,
+valence.
 
 ## Tutorial
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ by fine-tuning the pre-trained
 model on
 [MSP-Podcast](https://ecs.utdallas.edu/research/researchlabs/msp-lab/MSP-Podcast.html)
 (v1.7).
+The pre-trained model was pruned
+from 24 to 12 transformer layers
+before fine-tuning. 
 
 ## Quick start
 


### PR DESCRIPTION
I think it would be nice to state at the beginning of the readme which w2v2 model we used and which data we fine tuned on.

![image](https://user-images.githubusercontent.com/173624/155491331-f14b9b01-8490-4f58-9f10-7da9b98889d8.png)


In addition, I added details on the output of the model after the example.

![image](https://user-images.githubusercontent.com/173624/155489416-1b0909c3-df95-437a-86ce-507822f6f866.png)
