### PR TITLE
Add URL for paper in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ $ jupyter notebook notebook.ipynb
 
 ## Citation
 
-If you use our model in your own work, please cite the following paper:
+If you use our model in your own work, please cite the following
+[paper](https://arxiv.org/abs/2203.07378):
 
 ```bibtex
 @article{wagner2022dawn,


### PR DESCRIPTION
I also added a link to the paper above the BibTeX code:

![image](https://user-images.githubusercontent.com/173624/158752066-1a0f2db4-744b-4ec4-b45d-e42b924d4176.png)
