### PR TITLE
Fix: require audobject>=0.7.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 audb>=1.2.5
 audmetric>=1.1.3
+audobject>=0.7.2
 audonnx>=0.5.0
 audplot>=1.4.0
 gTTS


### PR DESCRIPTION
Closes #13 

It uses a new version of `audobject` which works fine together with `audinterface>=0.9.0`.